### PR TITLE
Move esbuild to devDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   "keywords": [],
   "author": "Victor Yoalli",
   "license": "MIT",
-  "dependencies": {
+  "devDependencies": {
     "esbuild": "^0.12.22"
   },
   "scripts": {


### PR DESCRIPTION
Hey!

I'm a big fan of this project, this has been a super useful starting point for several intrernal tools I've built with Alpine.js.

I just had a query. Is there a specific reason that esbuild is not a dev dependency? Maybe I'm missing something, but it shouldn't be required when using the result package?

Thanks for your work on this project!